### PR TITLE
Update English-Japanese parts in simultaneous.md

### DIFF
--- a/_pages/2022/shared-tasks/simultaneous.md
+++ b/_pages/2022/shared-tasks/simultaneous.md
@@ -94,7 +94,7 @@ You may use the same training and development data available for the [Offline Sp
 
 ### English-Japanese
 
-We provide a version of MuST-C prepared for this shared task [MuST-C v2.0 English-Japanese](https://dsc-nlp.naist.jp/data/MuST-C_EnJa_IWSLT2022/) for training and development.
+We provide a version of MuST-C prepared for this shared task [MuST-C v2.0](https://ict.fbk.eu/must-c/) for training and development.
 For training, you may also use the parallel data and monolingual data available for the [English-Japanese WMT20 news task](http://statmt.org/wmt20/translation-task.html).
 
 ## Baseline Implementation and Example

--- a/_pages/2022/shared-tasks/simultaneous.md
+++ b/_pages/2022/shared-tasks/simultaneous.md
@@ -94,10 +94,8 @@ You may use the same training and development data available for the [Offline Sp
 
 ### English-Japanese
 
-For training, you may use the parallel data and monolingual data available for the [English-Japanese WMT20 news task](http://statmt.org/wmt20/translation-task.html).
-For development, you may use the [IWSLT 2017 development sets](https://wit3.fbk.eu/2017-01-c) and [IWSLT 2021 development set](https://drive.google.com/drive/folders/1uSkOT-XqbICMohnvfXdEFffKLdaQX0X7).
-You may also use [simultaneous interpretation transcripts for the IWSLT 2021 development set](https://drive.google.com/drive/folders/1bB1s9PKNoRoDFfc567J5zDMcYj_lFFEB) for the comparison with human interpretation, under the terms of use written in *README_before_download_enjaDevSI.txt*.
-
+We provide a version of MuST-C prepared for this shared task [MuST-C v2.0 English-Japanese](https://dsc-nlp.naist.jp/data/MuST-C_EnJa_IWSLT2022/) for training and development.
+For training, you may also use the parallel data and monolingual data available for the [English-Japanese WMT20 news task](http://statmt.org/wmt20/translation-task.html).
 
 ## Baseline Implementation and Example
 
@@ -151,7 +149,7 @@ If you encounter a bus error similar to this [issue](https://github.com/pytorch/
 When submitting your system, please make sure it works for the MuST-C dev and test sets. During the official evaluation, we will run the submitted system with the blind set.
 
 ### English-to-Japanese Text-to-Text Translation
-You can find instructions to train and evaluate an English-to-Japanese baseline system [here](https://github.com/pytorch/fairseq/blob/master/examples/simultaneous_translation/docs/enja-waitk.md).
+Baseline will be provided later in January 2022.
 
 ## System Submission
 


### PR DESCRIPTION
- Put a link to MuST-C English-Japanese (hosted by a NAIST web server)
- Remove the information on IWSLT 2017 and 2021 dev set to avoid possible data overlap with MuST-C.
- Put a mention about a baseline on English-Japanese